### PR TITLE
[Small fix] Avoid capitalize method, which removes all caps from string (except for first character).

### DIFF
--- a/slack_retro_bot_to_airtable.py
+++ b/slack_retro_bot_to_airtable.py
@@ -191,6 +191,7 @@ def handle_slack_button_click():
 
 def _get_command_action_and_params(command_text):
     """Parse the passed string for a command action and parameters."""
+
     command_components = command_text.split(' ')
     command_action = command_components[0].lower()
     command_params = ' '.join(command_components[1:])
@@ -199,12 +200,12 @@ def _get_command_action_and_params(command_text):
 
 def _add_retrospective_item_and_get_response(category, item_object, user_name):
     """Set the retrospective item for the passed parameters and return the approriate responses."""
+
     # Reject attempts to set reserved terms.
     if item_object.lower() in _ALL_CMDS:
         return "Sorry, but *{}* can't save *{}* because it's a reserved term.".format(
             _BOT_NAME, item_object)
 
-    item_object = item_object.capitalize()
     if not item_object:
         return 'Oops, you forgot to tell what was *{}*!'.format(category)
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/retrospective-bot/16)
<!-- Reviewable:end -->
