### PR TITLE
Fix python version to 3.6 while dependencies are not compatible with 3.7.

### DIFF
--- a/Dockerfile.deploy
+++ b/Dockerfile.deploy
@@ -1,4 +1,6 @@
-FROM python:3
+# Zappa (and AWS Lambda) support the following versions of Python: ['2.7', '3.6']
+# https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html
+FROM python:3.6
 
 WORKDIR /var/task
 COPY ./requirements.txt ./requirements.txt

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,6 @@
-FROM python:3
+# Zappa (and AWS Lambda) support the following versions of Python: ['2.7', '3.6']
+# https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html
+FROM python:3.6
 
 WORKDIR /test
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bayesimpact/retrospective-bot/17)
<!-- Reviewable:end -->
